### PR TITLE
line_itemを更新できない問題対応

### DIFF
--- a/lib/twitter-ads/campaign/line_item.rb
+++ b/lib/twitter-ads/campaign/line_item.rb
@@ -91,6 +91,9 @@ module TwitterAds
       # If automatically_set_bid is set, bid_type must not be set.
       params.delete(:bid_type) if params.has_key?(:automatically_select_bid)
 
+      # If set to true, bid_amount_local_micro must be NULL
+      params.store(:bid_amount_local_micro, nil) if params[:automatically_select_bid]
+
       # advertiser_user_id is currently beta-only and causes an error when sent.
       params.delete(:advertiser_user_id)
 


### PR DESCRIPTION
# 概要

line_itemを `automatically_select_bid=true` にした時に、`bid_amount_local_micro=nil` もリクエストにつけないといけないが、DSL#to_paramsでnilのパラメータは削除されている
