### PR TITLE
LineItemのパラメータ付加条件変更

### DIFF
--- a/lib/twitter-ads/campaign/line_item.rb
+++ b/lib/twitter-ads/campaign/line_item.rb
@@ -92,8 +92,8 @@ module TwitterAds
       params.delete(:bid_type) if params.has_key?(:automatically_select_bid)
 
       # If set to true, bid_amount_local_micro must be NULL
-      params.store(:bid_amount_local_micro, nil) if params[:automatically_select_bid]
-
+      params.store(:bid_amount_local_micro, nil) if params[:automatically_select_bid] && self.id.present?
+      
       # advertiser_user_id is currently beta-only and causes an error when sent.
       params.delete(:advertiser_user_id)
 


### PR DESCRIPTION
# 概要

LineItemのcreateとupdateでbid_amount_local_microの許容する値が異なっていたので、updateの時のみ付加するように変更
