### PR TITLE
web_event_tag追加

### DIFF
--- a/lib/twitter-ads.rb
+++ b/lib/twitter-ads.rb
@@ -69,4 +69,6 @@ require 'twitter-ads/creative/video'
 
 require 'twitter-ads/targeting/reach_estimate'
 
+require 'twitter-ads/measurement/web_event_tag'
+
 require 'twitter-ads/legacy.rb'

--- a/lib/twitter-ads/account.rb
+++ b/lib/twitter-ads/account.rb
@@ -227,6 +227,10 @@ module TwitterAds
       response.body[:data]
     end
 
+    def web_event_tags(id = nil, opts = {})
+      load_resource(WebEventTag, id, opts)
+    end
+
     private
 
     def load_resource(klass, id = nil, opts = {})

--- a/lib/twitter-ads/campaign/campaign.rb
+++ b/lib/twitter-ads/campaign/campaign.rb
@@ -7,6 +7,7 @@ module TwitterAds
     include TwitterAds::DSL
     include TwitterAds::Resource
     include TwitterAds::Persistence
+    include TwitterAds::Analytics
 
     attr_reader :account
 

--- a/lib/twitter-ads/campaign/targeting_criteria.rb
+++ b/lib/twitter-ads/campaign/targeting_criteria.rb
@@ -22,6 +22,7 @@ module TwitterAds
     property :targeting_value
     property :tailored_audience_expansion, type: :bool
     property :tailored_audience_type
+    property :location_type
 
     RESOURCE_COLLECTION = '/1/accounts/%{account_id}/targeting_criteria'.freeze # @api private
     RESOURCE            = '/1/accounts/%{account_id}/targeting_criteria/%{id}'.freeze # @api private

--- a/lib/twitter-ads/measurement/web_event_tag.rb
+++ b/lib/twitter-ads/measurement/web_event_tag.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+# Copyright (C) 2015 Twitter, Inc.
+
+module TwitterAds
+  class WebEventTag
+
+    include TwitterAds::DSL
+    include TwitterAds::Resource
+    include TwitterAds::Persistence
+
+    property :id, read_only: true
+    property :name
+    property :retargeting_enabled, type: :bool
+    property :status, read_only: true
+    property :type
+    property :view_through_window
+    property :deleted, read_only: true
+    property :embed_code, read_only: true
+    property :click_window
+
+    RESOURCE_COLLECTION = '/1/accounts/%{account_id}/web_event_tags'.freeze # @api private
+
+    def initialize(account)
+      @account = account
+      self
+    end
+  end
+end

--- a/lib/twitter-ads/resources/analytics.rb
+++ b/lib/twitter-ads/resources/analytics.rb
@@ -8,6 +8,7 @@ module TwitterAds
   module Analytics
 
     ANALYTICS_MAP = {
+      'TwitterAds::Campaign' => 'CAMPAIGN'.freeze,
       'TwitterAds::LineItem' => 'LINE_ITEM'.freeze,
       'TwitterAds::OrganicTweet' => 'ORGANIC_TWEET'.freeze,
       'TwitterAds::Creative::PromotedTweet' => 'PROMOTED_TWEET'.freeze


### PR DESCRIPTION
# 概要

キーコンバージョンイベントを取得・更新するクラスを追加

```
web_event_tag = account.web_event_tags.first
=> #<TwitterAds::WebEventTag:0x70171600346180 id="l5gge">
web_event_tag.class.instance_methods(false).reject {|method| method.match(/=\Z/) }.map {|method| "#{method} = #{web_event_tag.send(method)}"}
=> ["name = Site Visitors",
 "status = UNVERIFIED",
 "type = SITE_VISIT",
 "id = l5gge",
 "deleted = false",
 "retargeting_enabled = true",
 "view_through_window = 1",
 "embed_code = <script src=\"//platform.twitter.com/oct.js\" type=\"text/javascript\">...",
 "click_window = 30"]
```
