### PR TITLE
app_event_tags API追加

### DIFF
--- a/lib/twitter-ads.rb
+++ b/lib/twitter-ads.rb
@@ -70,5 +70,6 @@ require 'twitter-ads/creative/video'
 require 'twitter-ads/targeting/reach_estimate'
 
 require 'twitter-ads/measurement/web_event_tag'
+require 'twitter-ads/measurement/app_event_tag'
 
 require 'twitter-ads/legacy.rb'

--- a/lib/twitter-ads/account.rb
+++ b/lib/twitter-ads/account.rb
@@ -231,6 +231,10 @@ module TwitterAds
       load_resource(WebEventTag, id, opts)
     end
 
+    def app_event_tags(id = nil, opts = {})
+      load_resource(AppEventTag, id, opts)
+    end
+
     private
 
     def load_resource(klass, id = nil, opts = {})

--- a/lib/twitter-ads/measurement/app_event_tag.rb
+++ b/lib/twitter-ads/measurement/app_event_tag.rb
@@ -9,11 +9,9 @@ module TwitterAds
     include TwitterAds::Persistence
 
     property :id, read_only: true
-    property :name
     property :account_id
     property :app_store_identifier
     property :os_type
-    property :status, read_only: true
     property :conversion_type
     property :provider_app_event_id
     property :provider_app_event_name

--- a/lib/twitter-ads/measurement/app_event_tag.rb
+++ b/lib/twitter-ads/measurement/app_event_tag.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+# Copyright (C) 2015 Twitter, Inc.
+
+module TwitterAds
+  class AppEventTag
+
+    include TwitterAds::DSL
+    include TwitterAds::Resource
+    include TwitterAds::Persistence
+
+    property :id, read_only: true
+    property :name
+    property :account_id
+    property :app_store_identifier
+    property :os_type
+    property :status, read_only: true
+    property :conversion_type
+    property :provider_app_event_id
+    property :provider_app_event_name
+    property :deleted, read_only: true
+    property :post_view_attribution_window
+    property :post_engagement_attribution_window
+
+    RESOURCE_COLLECTION = '/1/accounts/%{account_id}/app_event_tags'.freeze # @api private
+
+    def initialize(account)
+      @account = account
+      self
+    end
+  end
+end


### PR DESCRIPTION
# 概要

web_event_tagのapp版も追加

```
twitter-ads v1.0.0 >> event_tag = account.app_event_tags.first
=> #<TwitterAds::AppEventTag:0x70298171593900 id="k2v">
twitter-ads v1.0.0 >> event_tag.class.instance_methods(false).reject {|method| method.match(/=\Z/) }.map {|method| "#{method} = #{event_tag.send(method)}"}
=> ["id = k2v",
 "account_id = 2jzxdm3",
 "deleted = false",
 "os_type = IOS",
 "app_store_identifier = 9xxxxxxxxx",
 "conversion_type = INSTALL",
 "provider_app_event_id = 1xxx",
 "provider_app_event_name = hoge",
 "post_view_attribution_window = 1",
 "post_engagement_attribution_window = 30"]
```
