### PR TITLE
プロパティ追加

### DIFF
--- a/lib/twitter-ads/campaign/line_item.rb
+++ b/lib/twitter-ads/campaign/line_item.rb
@@ -32,6 +32,7 @@ module TwitterAds
     property :automatically_select_bid
     property :bid_amount_local_micro
     property :total_budget_amount_local_micro
+    property :target_cpa_local_micro
 
     # beta (not yet generally available)
     property :advertiser_user_id


### PR DESCRIPTION
# 概要
WEBSITE_CONVERSIONSのキャンペーンを作成する際にはtarget_cpa_local_microのパラメータが必須だった