### PR TITLE
iab_categories追加

### DIFF
--- a/lib/twitter-ads.rb
+++ b/lib/twitter-ads.rb
@@ -35,6 +35,7 @@ require 'twitter-ads/campaign/line_item'
 require 'twitter-ads/campaign/promotable_user'
 require 'twitter-ads/campaign/targeting_criteria'
 require 'twitter-ads/campaign/tweet'
+require 'twitter-ads/campaign/iab_category'
 
 require 'twitter-ads/enum'
 

--- a/lib/twitter-ads/campaign/iab_category.rb
+++ b/lib/twitter-ads/campaign/iab_category.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+# Copyright (C) 2015 Twitter, Inc.
+
+module TwitterAds
+  class IABCategory
+
+    include TwitterAds::DSL
+    include TwitterAds::Resource
+
+    attr_reader :account
+
+    property :id, read_only: true
+    property :name, read_only: true
+    property :parent_id, read_only: true
+
+    RESOURCE_COLLECTION = '/1/iab_categories'.freeze # @api private
+
+    def initialize(account)
+      @account = account
+      self
+    end
+  end
+end


### PR DESCRIPTION
# 概要
WEBSITE_CONVERSIONSで使うIABカテゴリを取得するためのAPI追加

https://dev.twitter.com/ads/reference/get/iab_categories