### PR TITLE
chunk_size変更

### DIFF
--- a/lib/twitter-ads/http/ton_upload.rb
+++ b/lib/twitter-ads/http/ton_upload.rb
@@ -59,7 +59,7 @@ module TwitterAds
         response.headers['location'][0]
       else
         response   = init_chunked_upload
-        chunk_size = response.headers['x-ton-min-chunk-size'][0].to_i
+        chunk_size = response.headers['x-ton-max-chunk-size'][0].to_i
         location   = response.headers['location'][0]
 
         File.open(@file_path) do |file|


### PR DESCRIPTION
# 概要
チャンクサイズが小さいとリクエスト回数が多すぎてAPI Rate limitになるので、チャンクサイズを大きくして、リクエスト回数を減らす